### PR TITLE
feat: use once_cell instead of lazy_static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ version = "0.5.3-alpha.0"
 anyhow = {version = "1", optional = true}
 clap = {version = "2.32", optional = true}
 itertools = {version = "0.10.3", optional = true}
-lazy_static = "1.4.0"
+once_cell = "1.10.0"
 quote = {version = "1", optional = true}
 rust-i18n-extract = {path = "./crates/extract", version = "0.3", optional = true}
 rust-i18n-macro = {path = "./crates/macro", version = "0.3"}

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add crate dependencies in your Cargo.toml and setup I18n config:
 
 ```toml
 [dependencies]
-lazy_static = "1.4.0"
+once_cell = "1.10.0"
 rust-i18n = "0"
 
 [package.metadata.i18n]

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.3.0"
 
 [dependencies]
 glob = "0.3"
-lazy_static = "1.4.0"
+once_cell = "1.10.0"
 proc-macro2 = "1.0"
 quote = "1.0.2"
 rust-i18n-support = {path = "../support", version = "0.3"}

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -59,12 +59,10 @@ fn generate_code(translations: HashMap<String, String>) -> proc_macro2::TokenStr
 
     // result
     quote! {
-        lazy_static::lazy_static! {
-            static ref LOCALES: std::collections::HashMap<&'static str, &'static str> = rust_i18n::map! [
-                #(#locales)*
-                "" => ""
-            ];
-        }
+        static LOCALES: once_cell::sync::Lazy<std::collections::HashMap<&'static str, &'static str>> = once_cell::sync::Lazy::new(|| rust_i18n::map! [
+            #(#locales)*
+            "" => ""
+        ]);
 
 
         pub fn translate(locale: &str, key: &str) -> String {

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -9,7 +9,7 @@ version = "0.3.0"
 
 [dependencies]
 glob = "0.3"
-lazy_static = "1.4.0"
+once_cell = "1.10.0"
 proc-macro2 = "1.0"
 serde = "1"
 serde_json = "1"

--- a/examples/foo/Cargo.toml
+++ b/examples/foo/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.4.0"
+once_cell = "1.10.0"
 rust-i18n = {path = "../../../rust-i18n"}
 
 [package.metadata.i18n]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ Add crate dependencies in your Cargo.toml:
 
 ```toml
 [dependencies]
-lazy_static = "1.4.0"
+once_cell = "1.10.0"
 rust-i18n = "0"
 ```
 
@@ -67,13 +67,12 @@ rust_i18n::locale();
 ```
 */
 // include!(concat!(env!("OUT_DIR"), "/i18n.rs"));
+use once_cell::sync::Lazy;
 use std::sync::Mutex;
 
 pub use rust_i18n_macro::i18n;
 
-lazy_static::lazy_static! {
-    static ref CURRENT_LOCALE: Mutex<String> = Mutex::new(String::from("en"));
-}
+static CURRENT_LOCALE: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::from("en")));
 
 pub fn set_locale(locale: &str) {
     let mut current_locale = CURRENT_LOCALE.lock().unwrap();


### PR DESCRIPTION
使用 once_cell 代替 lazy_static 

1. [less macro, faster compiles](https://news.ycombinator.com/item?id=24672238)
2. [The once_cell API is currently being incorporated into the stdlib, easily adapt stdlib](https://github.com/rust-lang/rust/issues/74465)