### PR TITLE
Take language code from filename instead of `.yml` files

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,19 +82,17 @@ Make sure all YAML files (containing the localized mappings) are located in the 
 In the YAML files, specify the localization keys and their corresponding values, for example, in `en.yml`:
 
 ```yml
-en: # The language code of this mapping file
-  hello: Hello world # A simple key -> value mapping
-  messages:
-    hello: Hello, %{name} # A nested key.sub_key -> value mapping, in this case "messages.hello" maps to "Hello, %{name}"
+hello: Hello world # A simple key -> value mapping
+messages:
+  hello: Hello, %{name} # A nested key.sub_key -> value mapping, in this case "messages.hello" maps to "Hello, %{name}"
 ```
 
 And example of the `zh-CN.yml`:
 
 ```yml
-zh-CN:
-  hello: 你好世界
-  messages:
-    hello: 你好, %{name}
+hello: 你好世界
+messages:
+  hello: 你好, %{name}
 ```
 
 ### Loading Localized Strings in Rust

--- a/examples/app/locales/en.yml
+++ b/examples/app/locales/en.yml
@@ -1,2 +1,1 @@
-en:
-  hello: Hello, %{name}!
+hello: Hello, %{name}!

--- a/examples/app/locales/fr.yml
+++ b/examples/app/locales/fr.yml
@@ -1,2 +1,1 @@
-fr:
-  hello: Bonjour, %{name}!
+hello: Bonjour, %{name}!

--- a/examples/app/locales/view.en.yml
+++ b/examples/app/locales/view.en.yml
@@ -1,7 +1,6 @@
-en:
-  view:
-    buttons:
-      ok: Ok
-      cancel: Cancel
-    datetime:
-      about_x_hours: about %{count} hours
+view:
+  buttons:
+    ok: Ok
+    cancel: Cancel
+  datetime:
+    about_x_hours: about %{count} hours

--- a/examples/app/locales/view.fr.yml
+++ b/examples/app/locales/view.fr.yml
@@ -1,7 +1,6 @@
-fr:
-  view:
-    buttons:
-      ok: Ok
-      cancel: Cancel
-    datetime:
-      about_x_hours: environ %{count} heures
+view:
+  buttons:
+    ok: Ok
+    cancel: Cancel
+  datetime:
+    about_x_hours: environ %{count} heures

--- a/examples/foo/locales/en.yml
+++ b/examples/foo/locales/en.yml
@@ -1,2 +1,1 @@
-en:
-  hello: Foo - Hello, World!
+hello: Foo - Hello, World!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,10 +36,9 @@ locales/
 For example of `en.yml`:
 
 ```yml
-en:
-  hello: Hello world
-  messages:
-    hello: Hello, %{name}
+hello: Hello world
+messages:
+  hello: Hello, %{name}
 ```
 
 Now you can use `t!` macro in anywhere.

--- a/tests/locales/de.yml
+++ b/tests/locales/de.yml
@@ -1,4 +1,3 @@
-de:
-  hello: Bar - Hallo Welt!
-  messages:
-    hello: Hallo, %{name}!
+hello: Bar - Hallo Welt!
+messages:
+  hello: Hallo, %{name}!

--- a/tests/locales/en.yml
+++ b/tests/locales/en.yml
@@ -1,15 +1,14 @@
-en:
-  hello: Bar - Hello, World!
-  custom:
-    greeting: Hello, %{name}!!!
-  a:
-    very:
-      nested:
-        message: "Hello, %{name}. Your message is: %{msg}"
-  messages:
-    zero: You have no messages.
-    one: You have one message.
-    other: You have %{count} messages.
-    hello: Hello, %{name}!
-  missing:
-    default: Sorry, that translation doesn't exist.
+hello: Bar - Hello, World!
+custom:
+  greeting: Hello, %{name}!!!
+a:
+  very:
+    nested:
+      message: "Hello, %{name}. Your message is: %{msg}"
+messages:
+  zero: You have no messages.
+  one: You have one message.
+  other: You have %{count} messages.
+  hello: Hello, %{name}!
+missing:
+  default: Sorry, that translation doesn't exist.

--- a/tests/locales/user.en.yml
+++ b/tests/locales/user.en.yml
@@ -1,6 +1,5 @@
-en:
+user:
+  title: User Title
+messages:
   user:
-    title: User Title
-  messages:
-    user:
-      title: Message User Title
+    title: Message User Title


### PR DESCRIPTION
Before

```yml
en: # The language code of this mapping file
  hello: Hello world # A simple key -> value mapping
  messages:
    hello: Hello, %{name} # A nested key.sub_key -> value mapping, in this case "messages.hello" maps to "Hello, %{name}"
```

After that, there is no need to add a first-level language code to the `.yml` file

```yml
hello: Hello world # A simple key -> value mapping
messages:
  hello: Hello, %{name} # A nested key.sub_key -> value mapping, in this case "messages.hello" maps to "Hello, %{name}"
```

This modification makes the locales `.yml` file more standardized, and some vscode plugins can be used directly, such as i18n-ally

`.vscode/i18n-ally-custom-framework.yml`

```yml
languageIds:
  - rust

usageMatchRegex:
  - "[^\\w\\d]t!\\(['\"]({key})['\"]"

monopoly: true
```

Work for rust now!