### PR TITLE
Match newlines in i18n-ally-custom-framework.yml

### DIFF
--- a/.vscode/i18n-ally-custom-framework.yml
+++ b/.vscode/i18n-ally-custom-framework.yml
@@ -2,6 +2,6 @@ languageIds:
   - rust
 
 usageMatchRegex:
-  - "[^\\w\\d]t!\\(['\"]({key})['\"]"
+  - "[^\\w\\d]t!\\([\\s\\n\\r]*['\"]({key})['\"]"
 
 monopoly: true


### PR DESCRIPTION
The original configuration does not recognize statements containing newlines, but the situation is more common during use.
For example:

```
t!(
    "app.depository_path",
    path = get_depository_dir().to_str().unwrap()
)
```