### PR TITLE
Remove once_cell::sync::Lazy dependency for std::sync::OnceLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["i18n", "yml", "localization", "internationalization"]
 license = "MIT"
 name = "rust-i18n"
 readme = "README.md"
+rust-version = "1.70"
 repository = "https://github.com/longbridgeapp/rust-i18n"
 version = "1.2.2-alpha.0"
 
@@ -16,7 +17,6 @@ version = "1.2.2-alpha.0"
 anyhow = {version = "1", optional = true}
 clap = {version = "2.32", optional = true}
 itertools = {version = "0.10.3", optional = true}
-once_cell = "1.10.0"
 quote = {version = "1", optional = true}
 rust-i18n-extract = {path = "./crates/extract", version = "1.1.0", optional = true}
 rust-i18n-macro = {path = "./crates/macro", version = "1.2.0"}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Add crate dependencies in your Cargo.toml and setup I18n config:
 
 ```toml
 [dependencies]
-once_cell = "1.10.0"
 rust-i18n = "1"
 ```
 

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -11,7 +11,6 @@ version = "1.2.1"
 
 [dependencies]
 glob = "0.3"
-once_cell = "1.10.0"
 proc-macro2 = "1.0"
 quote = "1.0.2"
 rust-i18n-support = {path = "../support", version = "1.1.0"}

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -9,7 +9,6 @@ version = "1.1.0"
 
 [dependencies]
 glob = "0.3"
-once_cell = "1.10.0"
 proc-macro2 = "1.0"
 serde = "1"
 serde_json = "1"

--- a/examples/app-load-path/Cargo.toml
+++ b/examples/app-load-path/Cargo.toml
@@ -7,5 +7,4 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.10.0"
 rust-i18n = {path = "../../../rust-i18n"}

--- a/examples/app-workspace/app1/Cargo.toml
+++ b/examples/app-workspace/app1/Cargo.toml
@@ -6,5 +6,4 @@ version = "0.1.0"
 [dependencies]
 example-base = {path = "../crates/example-base"}
 lazy_static = "1.4"
-once_cell = "1.10.0"
 rust-i18n = {path = "../../../../rust-i18n"}

--- a/examples/app-workspace/crates/example-base/Cargo.toml
+++ b/examples/app-workspace/crates/example-base/Cargo.toml
@@ -7,5 +7,4 @@ version = "0.1.0"
 
 [dependencies]
 lazy_static = "1.4"
-once_cell = "1.10.0"
 rust-i18n = {path = "../../../../../rust-i18n"}

--- a/examples/foo/Cargo.toml
+++ b/examples/foo/Cargo.toml
@@ -7,7 +7,6 @@ version = "0.1.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = "1.10.0"
 rust-i18n = {path = "../../../rust-i18n"}
 
 [package.metadata.i18n]


### PR DESCRIPTION
## Description

Since `std::sync::OnceLock` is now stable in `1.70`, `once_lock` can now be safely be removed. Also, this requires a version update by bumping the minimum version so this should be considered after a few more versions.