### PR TITLE
Add Backend design, allows to custom backend.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT"
 name = "rust-i18n"
 readme = "README.md"
 repository = "https://github.com/longbridgeapp/rust-i18n"
-version = "1.2.2"
+version = "2.0.0"
 
 [dependencies]
 anyhow = {version = "1", optional = true}
@@ -18,8 +18,9 @@ clap = {version = "2.32", optional = true}
 itertools = {version = "0.10.3", optional = true}
 once_cell = "1.10.0"
 quote = {version = "1", optional = true}
-rust-i18n-extract = {path = "./crates/extract", version = "1.1.0", optional = true}
-rust-i18n-macro = {path = "./crates/macro", version = "1.3.0"}
+rust-i18n-extract = {path = "./crates/extract", version = "2.0.0", optional = true}
+rust-i18n-support = {path = "./crates/support", version = "2.0.0"}
+rust-i18n-macro = {path = "./crates/macro", version = "2.0.0"}
 serde = "1"
 serde_derive = "1"
 toml = "0.5.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ toml = "0.5.8"
 
 [dev-dependencies]
 foo = {path = "examples/foo"}
+criterion = "0.3"
 
 [features]
 default = ["rust-i18n-extract", "clap", "anyhow", "quote", "itertools"]
@@ -52,3 +53,7 @@ members = [
     "examples/app-load-path",
     "examples/foo",
 ]
+
+[[bench]]
+harness = false
+name = "bench"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,3 +43,12 @@ test = true
 name = "cargo-i18n"
 path = "src/main.rs"
 required-features = ["default"]
+
+[workspace]
+members = [
+    "crates/extract",
+    "crates/support",
+    "crates/macro",
+    "examples/app-load-path",
+    "examples/foo",
+]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,5 @@ release\:extract:
 release:
 	cargo release
 test:
-	RUST_TEST_THREADS=1 cargo test
-	RUST_TEST_THREADS=1 cargo test --manifest-path examples/app-workspace/Cargo.toml
-	RUST_TEST_THREADS=1 cargo test --manifest-path examples/foo/Cargo.toml
-	RUST_TEST_THREADS=1 cargo test --manifest-path examples/app-load-path/Cargo.toml
+	RUST_TEST_THREADS=1 cargo test --workspace
+	RUST_TEST_THREADS=1 cargo test --manifest-path examples/app-workspace/Cargo.toml --workspace

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ rust_i18n::i18n!("locales");
 fn main() {
     println!("{}", t!("hello"));
 
-    // Use `available_locales` method to get all available locales.
-    println!("{:?}", available_locales());
+    // Use `available_locales!` method to get all available locales.
+    println!("{:?}", rust_i18n::available_locales!());
 }
 ```
 

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -1,0 +1,18 @@
+use rust_i18n::t;
+
+rust_i18n::i18n!("./tests/locales");
+
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn bench_t(c: &mut Criterion) {
+    c.bench_function("t", |b| b.iter(|| t!("hello")));
+}
+
+fn bench_t_with_args(c: &mut Criterion) {
+    c.bench_function("t_with_args", |b| {
+        b.iter(|| t!("a.very.nested.message", name = "Jason", msg = "Bla bla"))
+    });
+}
+
+criterion_group!(benches, bench_t, bench_t_with_args);
+criterion_main!(benches);

--- a/crates/extract/Cargo.toml
+++ b/crates/extract/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 name = "rust-i18n-extract"
 readme = "../../README.md"
 repository = "https://github.com/longbridgeapp/rust-i18n"
-version = "1.1.0"
+version = "2.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -15,7 +15,7 @@ ignore = "0.4"
 proc-macro2 = {version = "1", features = ["span-locations"]}
 quote = "1"
 regex = "1"
-rust-i18n-support = {path = "../support", version = "1.1.0"}
+rust-i18n-support = {path = "../support", version = "2.0.0"}
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"

--- a/crates/extract/src/generator.rs
+++ b/crates/extract/src/generator.rs
@@ -23,16 +23,16 @@ pub fn generate<'a, P: AsRef<Path>>(
     let mut new_values: HashMap<String, String> = HashMap::new();
 
     for m in messages {
-        let key = format!("{}.{}", locale, m.key);
-
         if !m.locations.is_empty() {
             for _l in &m.locations {
                 // TODO: write file and line as YAML comment
             }
         }
 
-        if data.translations.get(&key).is_some() {
-            continue;
+        if let Some(trs) = data.get(locale) {
+            if trs.get(&m.key).is_some() {
+                continue;
+            }
         }
 
         let value = m.key.split(".").last().unwrap_or_default();

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 name = "rust-i18n-macro"
 readme = "../../README.md"
 repository = "https://github.com/longbridgeapp/rust-i18n"
-version = "1.3.0"
+version = "2.0.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -14,7 +14,7 @@ glob = "0.3"
 once_cell = "1.10.0"
 proc-macro2 = "1.0"
 quote = "1.0.2"
-rust-i18n-support = {path = "../support", version = "1.1.0"}
+rust-i18n-support = {path = "../support", version = "2.0.0"}
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -126,7 +126,7 @@ fn generate_code(
     // result
     quote! {
         /// I18n backend instance
-        static I18n: rust_i18n::once_cell::sync::Lazy<Box<dyn rust_i18n::Backend>> = rust_i18n::once_cell::sync::Lazy::new(|| {
+        static _RUEST_I18N_BACKEND: rust_i18n::once_cell::sync::Lazy<Box<dyn rust_i18n::Backend>> = rust_i18n::once_cell::sync::Lazy::new(|| {
             let items = [#(#all_translations),*];
             let locales = [#(#all_locales),*];
 
@@ -136,21 +136,25 @@ fn generate_code(
         static _RUST_I18N_FALLBACK_LOCALE: Option<&'static str> = #fallback;
 
         /// Get I18n text by locale and key
-        pub fn _rust_i18n_lookup(locale: &str, key: &str) -> String {
+        pub fn _rust_i18n_translate(locale: &str, key: &str) -> String {
             let target_key = format!("{}.{}", locale, key);
 
-            if let Some(value) = I18n.lookup(locale, key) {
+            if let Some(value) = i18n().translate(locale, key) {
                 return value.to_string();
             }
 
 
             if let Some(fallback) = _RUST_I18N_FALLBACK_LOCALE {
-                if let Some(value) = I18n.lookup(fallback, key) {
+                if let Some(value) = i18n().translate(fallback, key) {
                     return value.to_string();
                 }
             }
 
             return target_key
+        }
+
+        pub fn i18n() -> &'static dyn rust_i18n::Backend {
+            &**_RUEST_I18N_BACKEND
         }
     }
 }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -182,7 +182,7 @@ fn generate_code(
             return target_key
         }
 
-        pub fn _rust_i18n_available_locales() -> Vec<String> {
+        pub fn _rust_i18n_available_locales() -> Vec<&'static str> {
             let mut locales = _RUST_I18N_BACKEND.available_locales();
             locales.sort();
             locales

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -152,7 +152,7 @@ fn generate_code(
         use rust_i18n::BackendExt;
 
         /// I18n backend instance
-        static _RUEST_I18N_BACKEND: rust_i18n::once_cell::sync::Lazy<Box<dyn rust_i18n::Backend>> = rust_i18n::once_cell::sync::Lazy::new(|| {
+        static _RUST_I18N_BACKEND: rust_i18n::once_cell::sync::Lazy<Box<dyn rust_i18n::Backend>> = rust_i18n::once_cell::sync::Lazy::new(|| {
             let trs = [#(#all_translations),*];
             let locales = [#(#all_locales),*];
 
@@ -168,13 +168,13 @@ fn generate_code(
         pub fn _rust_i18n_translate(locale: &str, key: &str) -> String {
             let target_key = format!("{}.{}", locale, key);
 
-            if let Some(value) = i18n().translate(locale, key) {
+            if let Some(value) = _RUST_I18N_BACKEND.translate(locale, key) {
                 return value.to_string();
             }
 
 
             if let Some(fallback) = _RUST_I18N_FALLBACK_LOCALE {
-                if let Some(value) = i18n().translate(fallback, key) {
+                if let Some(value) = _RUST_I18N_BACKEND.translate(fallback, key) {
                     return value.to_string();
                 }
             }
@@ -182,8 +182,10 @@ fn generate_code(
             return target_key
         }
 
-        pub fn i18n() -> &'static dyn rust_i18n::Backend {
-            &**_RUEST_I18N_BACKEND
+        pub fn _rust_i18n_available_locales() -> Vec<String> {
+            let mut locales = _RUST_I18N_BACKEND.available_locales();
+            locales.sort();
+            locales
         }
     }
 }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -125,9 +125,11 @@ fn generate_code(
 
     // result
     quote! {
-        static _RUST_I18N_BACKEND: rust_i18n::once_cell::sync::Lazy<Box<dyn rust_i18n::Backend>> = rust_i18n::once_cell::sync::Lazy::new(|| {
+        /// I18n backend instance
+        static I18n: rust_i18n::once_cell::sync::Lazy<Box<dyn rust_i18n::Backend>> = rust_i18n::once_cell::sync::Lazy::new(|| {
             let items = [#(#all_translations),*];
             let locales = [#(#all_locales),*];
+
             Box::new(rust_i18n::SimpleBackend::new(items.into_iter().collect(), locales.into_iter().collect()))
         });
 
@@ -137,22 +139,18 @@ fn generate_code(
         pub fn _rust_i18n_lookup(locale: &str, key: &str) -> String {
             let target_key = format!("{}.{}", locale, key);
 
-            if let Some(value) = i18n_backend().lookup(locale, key) {
+            if let Some(value) = I18n.lookup(locale, key) {
                 return value.to_string();
             }
 
 
             if let Some(fallback) = _RUST_I18N_FALLBACK_LOCALE {
-                if let Some(value) = i18n_backend().lookup(fallback, key) {
+                if let Some(value) = I18n.lookup(fallback, key) {
                     return value.to_string();
                 }
             }
 
             return target_key
-        }
-
-        pub fn i18n_backend() -> &'static dyn rust_i18n::Backend {
-            &**_RUST_I18N_BACKEND
         }
     }
 }

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -5,7 +5,7 @@ license = "MIT"
 name = "rust-i18n-support"
 readme = "../../README.md"
 repository = "https://github.com/longbridgeapp/rust-i18n"
-version = "1.1.0"
+version = "2.0.0"
 
 [dependencies]
 globwalk = "0.8.1"

--- a/crates/support/src/backend.rs
+++ b/crates/support/src/backend.rs
@@ -1,0 +1,95 @@
+use std::collections::HashMap;
+
+// I18n backend trait
+pub trait Backend: Send + Sync + 'static {
+    // Insert the translations for the given locale
+    fn store(&mut self, locale: &str, data: &HashMap<String, String>);
+    // Return the available locales
+    fn available_locales(&self) -> Vec<String>;
+    // Lookup the translation for the given locale and key
+    fn lookup(&self, locale: &str, key: &str) -> Option<String>;
+}
+
+// Simple KeyValue storage backend
+pub struct SimpleBackend {
+    pub translations: HashMap<String, String>,
+    pub locales: HashMap<String, bool>,
+}
+
+impl SimpleBackend {
+    /// Create a new SimpleBackend.
+    ///
+    /// ```ignore
+    /// let trs = HashMap::<String, String>::new();
+    /// trs.insert("en.hello".into(), "Hello".into());
+    /// trs.insert("en.foo".into(), "Foo bar".into());
+    /// trs.insert("zh-CN.hello".into(), "你好".into());
+    /// trs.insert("zh-CN.foo".into(), "Foo 测试".into());
+    /// let locales = vec!["en", "zh-CN"];
+    /// let backend = SimpleBackend::new(trs, locales);
+    /// ```
+    pub fn new(translations: HashMap<&str, &str>, locales: Vec<&str>) -> Self {
+        SimpleBackend {
+            locales: locales.iter().map(|l| (l.to_string(), true)).collect(),
+            translations: translations
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+}
+
+impl Backend for SimpleBackend {
+    /// Insert the translations for the given locale.
+    ///
+    /// ```ignore
+    /// let trs = HashMap::<String, String>::new();
+    /// trs.insert("hello".into(), "Hello".into());
+    /// trs.insert("foo".into(), "Foo bar".into());
+    /// backend.store("en", &data);
+    /// ```
+    fn store(&mut self, locale: &str, data: &HashMap<String, String>) {
+        data.iter().for_each(|(k, v)| {
+            let k = format!("{}.{}", locale, k);
+            self.translations.insert(k, v.to_string());
+        });
+        self.locales.insert(locale.into(), true);
+    }
+
+    fn available_locales(&self) -> Vec<String> {
+        self.locales.keys().map(|k| k.to_string()).collect()
+    }
+
+    fn lookup(&self, locale: &str, key: &str) -> Option<String> {
+        let flatten_key = format!("{}.{}", locale, key);
+        self.translations.get(&flatten_key).map(|v| v.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use crate::SimpleBackend;
+
+    #[test]
+    fn test_simple_backend() {
+        let backend = SimpleBackend::new(HashMap::new(), vec![]);
+        let mut data = HashMap::<String, String>::new();
+        data.insert("hello".into(), "Hello".into());
+        data.insert("foo".into(), "Foo bar".into());
+        backend.store("en", &data);
+
+        let mut data_cn = HashMap::<String, String>::new();
+        data.insert("hello".into(), "你好".into());
+        data.insert("foo".into(), "Foo 测试".into());
+        backend.store("zh-CN", &data_cn);
+
+        assert_eq!(backend.lookup("en", "hello"), Some("Hello".into()));
+        assert_eq!(backend.lookup("en", "foo"), Some("Foo bar".into()));
+        assert_eq!(backend.lookup("zh-CN", "hello"), Some("你好".into()));
+        assert_eq!(backend.lookup("zh-CN", "foo"), Some("Foo 测试".into()));
+
+        assert_eq!(backend.available_locales(), vec!["en", "zh-CN"]);
+    }
+}

--- a/crates/support/src/backend.rs
+++ b/crates/support/src/backend.rs
@@ -3,9 +3,9 @@ use std::collections::HashMap;
 /// I18n backend trait
 pub trait Backend: Send + Sync + 'static {
     /// Return the available locales
-    fn available_locales(&self) -> Vec<String>;
+    fn available_locales(&self) -> Vec<&str>;
     /// Get the translation for the given locale and key
-    fn translate(&self, locale: &str, key: &str) -> Option<String>;
+    fn translate(&self, locale: &str, key: &str) -> Option<&str>;
 }
 
 pub trait BackendExt: Backend {
@@ -25,7 +25,7 @@ where
     A: Backend,
     B: Backend,
 {
-    fn available_locales(&self) -> Vec<String> {
+    fn available_locales(&self) -> Vec<&str> {
         let mut available_locales = self.0.available_locales();
         for locale in self.1.available_locales() {
             if !available_locales.contains(&locale) {
@@ -35,7 +35,7 @@ where
         available_locales
     }
 
-    fn translate(&self, locale: &str, key: &str) -> Option<String> {
+    fn translate(&self, locale: &str, key: &str) -> Option<&str> {
         self.1
             .translate(locale, key)
             .or_else(|| self.0.translate(locale, key))
@@ -92,19 +92,15 @@ impl SimpleBackend {
 }
 
 impl Backend for SimpleBackend {
-    fn available_locales(&self) -> Vec<String> {
-        let mut locales = self
-            .locales
-            .keys()
-            .map(|k| k.to_string())
-            .collect::<Vec<_>>();
+    fn available_locales(&self) -> Vec<&str> {
+        let mut locales = self.locales.keys().map(|k| k.as_str()).collect::<Vec<_>>();
         locales.sort();
         locales
     }
 
-    fn translate(&self, locale: &str, key: &str) -> Option<String> {
+    fn translate(&self, locale: &str, key: &str) -> Option<&str> {
         let flatten_key = format!("{}.{}", locale, key);
-        self.translations.get(&flatten_key).map(|v| v.to_string())
+        self.translations.get(&flatten_key).map(|v| v.as_str())
     }
 }
 

--- a/crates/support/src/backend.rs
+++ b/crates/support/src/backend.rs
@@ -8,7 +8,7 @@ pub trait Backend: Send + Sync + 'static {
     fn translate(&self, locale: &str, key: &str) -> Option<String>;
 }
 
-trait BackendExt: Backend {
+pub trait BackendExt: Backend {
     /// Extend backend to add more translations
     fn extend<T: Backend>(self, other: T) -> CombinedBackend<Self, T>
     where
@@ -18,7 +18,7 @@ trait BackendExt: Backend {
     }
 }
 
-struct CombinedBackend<A, B>(A, B);
+pub struct CombinedBackend<A, B>(A, B);
 
 impl<A, B> Backend for CombinedBackend<A, B>
 where

--- a/crates/support/src/lib.rs
+++ b/crates/support/src/lib.rs
@@ -4,8 +4,7 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 
 mod backend;
-pub use backend::Backend;
-pub use backend::SimpleBackend;
+pub use backend::{Backend, BackendExt, SimpleBackend};
 
 type Locale = String;
 type Value = serde_json::Value;

--- a/crates/support/src/lib.rs
+++ b/crates/support/src/lib.rs
@@ -3,9 +3,13 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::path::PathBuf;
 
-pub type Locale = String;
-pub type Value = serde_json::Value;
-pub type Translations = HashMap<Locale, Value>;
+mod backend;
+pub use backend::Backend;
+pub use backend::SimpleBackend;
+
+type Locale = String;
+type Value = serde_json::Value;
+type Translations = HashMap<Locale, Value>;
 
 pub fn is_debug() -> bool {
     std::env::var("RUST_I18N_DEBUG").unwrap_or_else(|_| "0".to_string()) == "1"
@@ -25,18 +29,13 @@ fn merge_value(a: &mut Value, b: &Value) {
     }
 }
 
-pub struct LocaleData {
-    pub translations: HashMap<String, String>,
-    pub locales: Vec<String>,
-}
-
 // Load locales into flatten key, value HashMap
-pub fn load_locales<F: Fn(&str) -> bool>(locales_path: &str, ignore_if: F) -> LocaleData {
-    let mut translations: Translations = HashMap::new();
-    let mut data = LocaleData {
-        translations: HashMap::new(),
-        locales: Vec::new(),
-    };
+pub fn load_locales<F: Fn(&str) -> bool>(
+    locales_path: &str,
+    ignore_if: F,
+) -> HashMap<String, HashMap<String, String>> {
+    let mut result: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut translations = HashMap::new();
 
     let path_pattern = format!("{locales_path}/**/*.{{yml,yaml,json,toml}}");
 
@@ -49,7 +48,7 @@ pub fn load_locales<F: Fn(&str) -> bool>(locales_path: &str, ignore_if: F) -> Lo
         if is_debug() {
             println!("cargo:i18n-error=path not exists: {}", locales_path);
         }
-        return data;
+        return result;
     }
 
     for entry in globwalk::glob(&path_pattern).expect("Failed to read glob pattern") {
@@ -70,8 +69,6 @@ pub fn load_locales<F: Fn(&str) -> bool>(locales_path: &str, ignore_if: F) -> Lo
 
         let ext = entry.extension().and_then(|s| s.to_str()).unwrap();
 
-        data.locales.push(locale.to_string());
-
         let file = File::open(&entry).expect("Failed to open file");
         let mut reader = std::io::BufReader::new(file);
         let mut content = String::new();
@@ -91,11 +88,10 @@ pub fn load_locales<F: Fn(&str) -> bool>(locales_path: &str, ignore_if: F) -> Lo
     }
 
     translations.iter().for_each(|(locale, trs)| {
-        let new_vars = extract_vars(locale.as_str(), &trs);
-        data.translations.extend(new_vars);
+        result.insert(locale.to_string(), flatten_keys(locale, trs));
     });
 
-    data
+    result
 }
 
 // Parse Translations from file to support multiple formats
@@ -116,7 +112,7 @@ fn parse_file(content: &str, ext: &str, locale: &str) -> Result<Translations, St
     }
 }
 
-pub fn extract_vars(prefix: &str, trs: &Value) -> HashMap<String, String> {
+fn flatten_keys(prefix: &str, trs: &Value) -> HashMap<String, String> {
     let mut v = HashMap::<String, String>::new();
     let prefix = prefix.to_string();
 
@@ -126,8 +122,12 @@ pub fn extract_vars(prefix: &str, trs: &Value) -> HashMap<String, String> {
         }
         serde_json::Value::Object(o) => {
             for (k, vv) in o {
-                let key = format!("{}.{}", prefix, k);
-                v.extend(extract_vars(key.as_str(), vv));
+                let key = if prefix.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{}.{}", prefix, k)
+                };
+                v.extend(flatten_keys(key.as_str(), vv));
             }
         }
         serde_json::Value::Null => {

--- a/crates/support/src/lib.rs
+++ b/crates/support/src/lib.rs
@@ -150,7 +150,6 @@ fn flatten_keys(prefix: &str, trs: &Value) -> HashMap<String, String> {
 #[cfg(test)]
 mod tests {
     use super::{merge_value, parse_file};
-    use std::path::PathBuf;
 
     #[test]
     fn test_merge_value() {
@@ -186,7 +185,7 @@ mod tests {
         assert_eq!(trs["zh-CN"]["foo"], "Foo");
 
         parse_file(content, "foo", "en").expect_err("Should error");
-        parse_file("invalid content", "yml", "en").expect_err("Should error");
+        parse_file("", "yml", "en").expect_err("Should error");
     }
 
     #[test]

--- a/examples/app-load-path/Cargo.toml
+++ b/examples/app-load-path/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 edition = "2021"
 name = "app-load-path"
-private = true
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/foo/Cargo.toml
+++ b/examples/foo/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 edition = "2021"
 name = "foo"
-private = true
 version = "0.1.0"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 #[doc(hidden)]
 pub use once_cell;
 pub use rust_i18n_macro::i18n;
-pub use rust_i18n_support::{Backend, SimpleBackend};
+pub use rust_i18n_support::{Backend, BackendExt, SimpleBackend};
 
 static CURRENT_LOCALE: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::from("en")));
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,18 +42,18 @@ pub fn locale() -> String {
 macro_rules! t {
     // t!("foo")
     ($key:expr) => {
-        crate::_rust_i18n_lookup(rust_i18n::locale().as_str(), $key)
+        crate::_rust_i18n_translate(rust_i18n::locale().as_str(), $key)
     };
 
     // t!("foo", locale="en")
     ($key:expr, locale=$locale:expr) => {
-        crate::_rust_i18n_lookup($locale, $key)
+        crate::_rust_i18n_translate($locale, $key)
     };
 
     // t!("foo", locale="en", a=1, b="Foo")
     ($key:expr, locale=$locale:expr, $($var_name:tt = $var_val:expr),+ $(,)?) => {
         {
-            let mut message = crate::_rust_i18n_lookup($locale, $key);
+            let mut message = crate::_rust_i18n_translate($locale, $key);
             $(
                 let var = stringify!($var_name).trim_matches('"');
                 let mut holder = std::string::String::from("%{");
@@ -98,4 +98,12 @@ macro_rules! map {
         )+
         m
     }};
+}
+
+/// Set I18n backend
+#[macro_export]
+macro_rules! set_backend {
+    ($backend:tt) => {
+        // $crate::_rust_i18n_set_backend($backend);
+    };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Mutex;
 #[doc(hidden)]
 pub use once_cell;
 pub use rust_i18n_macro::i18n;
+pub use rust_i18n_support::{Backend, SimpleBackend};
 
 static CURRENT_LOCALE: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::from("en")));
 
@@ -41,18 +42,18 @@ pub fn locale() -> String {
 macro_rules! t {
     // t!("foo")
     ($key:expr) => {
-        crate::_rust_i18n_translate(rust_i18n::locale().as_str(), $key)
+        crate::_rust_i18n_lookup(rust_i18n::locale().as_str(), $key)
     };
 
     // t!("foo", locale="en")
     ($key:expr, locale=$locale:expr) => {
-        crate::_rust_i18n_translate($locale, $key)
+        crate::_rust_i18n_lookup($locale, $key)
     };
 
     // t!("foo", locale="en", a=1, b="Foo")
     ($key:expr, locale=$locale:expr, $($var_name:tt = $var_val:expr),+ $(,)?) => {
         {
-            let mut message = crate::_rust_i18n_translate($locale, $key);
+            let mut message = crate::_rust_i18n_lookup($locale, $key);
             $(
                 let var = stringify!($var_name).trim_matches('"');
                 let mut holder = std::string::String::from("%{");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,22 +88,15 @@ macro_rules! t {
     };
 }
 
-#[doc(hidden)]
-#[macro_export]
-macro_rules! map {
-    {$($key:expr => $value:expr),+} => {{
-        let mut m = std::collections::HashMap::new();
-        $(
-            m.insert($key, $value);
-        )+
-        m
-    }};
-}
-
-/// Set I18n backend
-#[macro_export]
-macro_rules! set_backend {
-    ($backend:tt) => {
-        // $crate::_rust_i18n_set_backend($backend);
+/// Get available locales
+///
+/// ```ignore
+/// rust_i18n::available_locales!();
+/// // => ["en", "zh-CN"]
+/// ```
+#[macro_export(local_inner_macros)]
+macro_rules! available_locales {
+    () => {
+        crate::_rust_i18n_available_locales()
     };
 }

--- a/tests/intergartion_test.rs
+++ b/tests/intergartion_test.rs
@@ -50,7 +50,7 @@ mod tests {
 
     #[test]
     fn test_available_locales() {
-        let mut locales = crate::i18n_backend().available_locales();
+        let mut locales = crate::I18n.available_locales();
         locales.sort();
 
         assert_eq!(locales, &["en", "zh-CN"]);

--- a/tests/intergartion_test.rs
+++ b/tests/intergartion_test.rs
@@ -1,4 +1,30 @@
-rust_i18n::i18n!("./tests/locales", fallback = "en");
+struct TestBackend {}
+
+impl TestBackend {
+    fn new() -> Self {
+        return Self {};
+    }
+}
+
+impl rust_i18n::Backend for TestBackend {
+    fn available_locales(&self) -> Vec<String> {
+        return vec!["pt".to_string(), "en".to_string()];
+    }
+
+    fn translate(&self, locale: &str, key: &str) -> Option<String> {
+        if locale == "pt" {
+            return Some(format!("pt-fake.{key}"));
+        }
+
+        return None;
+    }
+}
+
+rust_i18n::i18n!(
+    "./tests/locales",
+    fallback = "en",
+    backend = TestBackend::new()
+);
 
 #[cfg(test)]
 mod tests {
@@ -53,7 +79,7 @@ mod tests {
         let mut locales = crate::i18n().available_locales();
         locales.sort();
 
-        assert_eq!(locales, &["en", "zh-CN"]);
+        assert_eq!(locales, &["en", "pt", "zh-CN"]);
     }
 
     #[test]
@@ -218,12 +244,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_translations() {
-        // crate::i18n().store(
-        //     "en",
-        //     rust_i18n::map! {
-        //         "bar" => "Hello, %{name}!"
-        //     },
-        // );
+    fn test_extend_backend() {
+        assert_eq!(t!("foo", locale = "pt"), "pt-fake.foo")
     }
 }

--- a/tests/intergartion_test.rs
+++ b/tests/intergartion_test.rs
@@ -76,10 +76,7 @@ mod tests {
 
     #[test]
     fn test_available_locales() {
-        let mut locales = crate::i18n().available_locales();
-        locales.sort();
-
-        assert_eq!(locales, &["en", "pt", "zh-CN"]);
+        assert_eq!(rust_i18n::available_locales!(), &["en", "pt", "zh-CN"]);
     }
 
     #[test]

--- a/tests/intergartion_test.rs
+++ b/tests/intergartion_test.rs
@@ -18,7 +18,7 @@ mod tests {
         #[test]
         fn test_fallback() {
             assert_eq!(
-                crate::tests::test2::_rust_i18n_translate("en", "missing.default"),
+                crate::tests::test2::_rust_i18n_lookup("en", "missing.default"),
                 "This is missing key fallbacked to en."
             );
         }
@@ -30,7 +30,7 @@ mod tests {
         #[test]
         fn test_fallback() {
             assert_eq!(
-                crate::tests::test3::_rust_i18n_translate("en", "fallback_to_cn"),
+                crate::tests::test3::_rust_i18n_lookup("en", "fallback_to_cn"),
                 "这是一个中文的翻译。"
             );
         }
@@ -43,14 +43,14 @@ mod tests {
     #[test]
     fn test_translate() {
         assert_eq!(
-            crate::_rust_i18n_translate("en", "hello"),
+            crate::_rust_i18n_lookup("en", "hello"),
             "Bar - Hello, World!"
         );
     }
 
     #[test]
     fn test_available_locales() {
-        let mut locales = crate::available_locales().to_vec();
+        let mut locales = crate::i18n_backend().available_locales();
         locales.sort();
 
         assert_eq!(locales, &["en", "zh-CN"]);

--- a/tests/intergartion_test.rs
+++ b/tests/intergartion_test.rs
@@ -1,19 +1,26 @@
-struct TestBackend {}
+use std::collections::HashMap;
+
+struct TestBackend {
+    trs: HashMap<String, String>,
+}
 
 impl TestBackend {
     fn new() -> Self {
-        return Self {};
+        let mut trs = HashMap::new();
+        trs.insert("foo".into(), format!("pt-fake.foo"));
+
+        return Self { trs };
     }
 }
 
 impl rust_i18n::Backend for TestBackend {
-    fn available_locales(&self) -> Vec<String> {
-        return vec!["pt".to_string(), "en".to_string()];
+    fn available_locales(&self) -> Vec<&str> {
+        return vec!["pt", "en"];
     }
 
-    fn translate(&self, locale: &str, key: &str) -> Option<String> {
+    fn translate(&self, locale: &str, key: &str) -> Option<&str> {
         if locale == "pt" {
-            return Some(format!("pt-fake.{key}"));
+            return self.trs.get(key).map(|v| v.as_str());
         }
 
         return None;

--- a/tests/intergartion_test.rs
+++ b/tests/intergartion_test.rs
@@ -18,7 +18,7 @@ mod tests {
         #[test]
         fn test_fallback() {
             assert_eq!(
-                crate::tests::test2::_rust_i18n_lookup("en", "missing.default"),
+                crate::tests::test2::_rust_i18n_translate("en", "missing.default"),
                 "This is missing key fallbacked to en."
             );
         }
@@ -30,7 +30,7 @@ mod tests {
         #[test]
         fn test_fallback() {
             assert_eq!(
-                crate::tests::test3::_rust_i18n_lookup("en", "fallback_to_cn"),
+                crate::tests::test3::_rust_i18n_translate("en", "fallback_to_cn"),
                 "这是一个中文的翻译。"
             );
         }
@@ -43,14 +43,14 @@ mod tests {
     #[test]
     fn test_translate() {
         assert_eq!(
-            crate::_rust_i18n_lookup("en", "hello"),
+            crate::_rust_i18n_translate("en", "hello"),
             "Bar - Hello, World!"
         );
     }
 
     #[test]
     fn test_available_locales() {
-        let mut locales = crate::I18n.available_locales();
+        let mut locales = crate::i18n().available_locales();
         locales.sort();
 
         assert_eq!(locales, &["en", "zh-CN"]);
@@ -215,5 +215,15 @@ mod tests {
             t!("custom.foo.toml-key", locale = "en"),
             "This is a toml key under the custom.foo"
         );
+    }
+
+    #[test]
+    fn test_add_translations() {
+        // crate::i18n().store(
+        //     "en",
+        //     rust_i18n::map! {
+        //         "bar" => "Hello, %{name}!"
+        //     },
+        // );
     }
 }


### PR DESCRIPTION
Ref #28 

## What's News

- Add `Backend` trait for allows us to customize the difference translations storage.
- Rewrite code to generate for use `backend` as code result to allows extending backend.
- Add public API `i18n()` method, this is Backend instance.

## Breaking Changes

- `available_locales` method has removed, use `rust_i18n::available_locales!()` instead.
- Refactor crate `rust_i18n_support` internal APIs, private some methods.

## How to extend backend

Write a struct that implements the `Backend` trait, and then implement the methods in the trait.

```rs
use rust_i18n::Backend;

pub struct MyBackend {
    trs: HashMap<String, HashMap<String, String>>,
}

impl MyBackend {
    fn new() -> Self {
        let trs = HashMap::new();
        trs.insert("en".to_string(), {
            let mut trs = HashMap::new();
            trs.insert("hello".to_string(), "Hello MyBackend".to_string());
            trs.insert("welcome".to_string(), "Welcome to use MyBackend".to_string());
            trs
        });
        
        return Self {
            trs
        };
    }
}

impl Backend for MyBackend {
    fn available_locales(&self) -> Vec<String> {
        todo!()
    }

    fn translate(&self, locale: &str, key: &str) -> Option<String> {
        // Write your own lookup logic here.
        // For example load from database
        return self.trs.get(locale)?.get(key).cloned();
    }
}
```

Now replace the default backend with your own backend.

```rs
rust_i18n::i18n!(fallback = "en", backend = MyBackend::new());

fn main() {
    t!("hello");
    // "Hello MyBackend"
    t!("welcome");
    // "Welcome to use MyBackend"
}
```

> This also will load local translates from `./locales` path, but your own `MyBackend` will priority than it.