### PR TITLE
Update toml in the main rust-i18n crate to match that of the rust-i18n-support crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ rust-i18n-support = {path = "./crates/support", version = "2.0.0"}
 rust-i18n-macro = {path = "./crates/macro", version = "2.0.0"}
 serde = "1"
 serde_derive = "1"
-toml = "0.5.8"
+toml = "0.7.4"
 
 [dev-dependencies]
 foo = {path = "examples/foo"}

--- a/src/config.rs
+++ b/src/config.rs
@@ -64,7 +64,8 @@ pub fn parse(contents: &str) -> io::Result<I18nConfig> {
         return Ok(I18nConfig::default());
     }
     let contents = contents.replace("[package.metadata.i18n]", "[i18n]");
-    let mut config: MainConfig = toml::from_str(&contents)?;
+    let mut config: MainConfig = toml::from_str(&contents)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e.to_string()))?;
 
     // Push default_locale
     config


### PR DESCRIPTION
toml 0.6 dropped the From<Error> implementation for std::io::Error