### PR TITLE
Do not use . in macro output if locale string is empty.

### DIFF
--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -178,6 +178,9 @@ fn generate_code(
                 }
             }
 
+            if locale.is_empty() {
+                return key.to_string();
+            }
             return format!("{}.{}", locale, key);
         }
 


### PR DESCRIPTION
The way I'd like to use the library is to keep English in the code and use the English string as the key for other languages. So if I have t!("Hello World!") and I have English selected, it would just output "Hello World!".

Luckily rust-i18n can ALMOST do what I want, but it wants to output the locale name in the missing translations. If I set the locale to be empty, it still wants to print the dot, which I don't want. So basically this whole long explanation is for why I want to remove a single dot and everything works great for me.

As a side note, I couldn't get the "cargo i18n" working properly, it would always think translations are missing, but if you're wondering, I have my own tool I originally made for C++ that checks through the files that then outputs

```
---
# "zThe secret number is: {secret_number}": "秘密の番号： {secret_number}" # Source text not found in any file!
"Hello, world!": "こんいちは世界！" # main.rs(11)
"Yellow world!": "黄色の世界！" # main.rs(13)
# "The secret number is: {secret_number}": TRANSLATION_MISSING # main.rs(27)
# "Please input your guess": TRANSLATION_MISSING # main.rs(29)
```
It will then edit the file itself every time the tool is run. (Using regexes, not YAML parser.) So it will handle cases of 1) Existing translations 2) Missing translations in the YAML 3) Existing translations for strings that are missing in code. (Like if someone edited the string in the code either by accident or on purpose, but didn't fix the translations.)

It will also output all the locations of the strings for reference.

I would put the tool somewhere, but it's in Python and requires some in-house libraries, so I'm not sure if it's worth the effort if no one would use it.