### PR TITLE
support _rust_i18n_translate in extractor

### DIFF
--- a/crates/extract/src/example.test.rs
+++ b/crates/extract/src/example.test.rs
@@ -18,5 +18,12 @@ and support mutiple YAML files merging."##);
         t!("The table below describes some of those behaviours.");
         // Will remove spaces for avoid duplication.
         t!("The table     below describes some     of those behaviours.");
+        //expanded/inlined macro t!()
+        crate::_rust_i18n_translate(rust_i18n::locale().as_str(), "Unfolded.test1.test")
+    }
+
+    //check if fn definition is not detected
+    pub fn _rust_i18n_translate(locale: &str, key: &str) -> String {
+        unimplemented!()
     }
 }


### PR DESCRIPTION
Currently, extractor supports only extracting from t!(...) placed directly in text. However sometimes it is more convenient to not place t!() calls directly in text, but rather use some macros, that would expand to/generate t!() calls. This requires either i18n understand & be able to expand macros or using some other tool that would expand macros prior i18n (i.e. cargo-expand). The problem is that cargo-expand expands all macros also t!() to  _rust_i18n_translate() call (which are not recognized by extractor). 
This PR enables extracting also from _rust_i18n_translate() calls.