### PR TITLE
Add a test for checking if tests are run single-threadedly.

### DIFF
--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -69,6 +69,17 @@ mod tests {
     }
 
     #[test]
+    fn check_test_environment() {
+        assert_eq!(
+            std::env::var("RUST_TEST_THREADS").unwrap_or_else(|_| "0".to_string()),
+            "1",
+            "The tests assume that they are run in single-threaded environment because \
+            setting the locale is a global state. If using cargo version prior to 1.56, \
+            You should set RUST_TEST_THREADS instead of running with --test-threads."
+        );
+    }
+
+    #[test]
     fn test_load() {
         assert!(load_locales("./tests/locales", |_| false)
             .get("en")


### PR DESCRIPTION
I apologize for spamming, I didn't realize I could do this before pushing the previous thing.

Not wanting to add extra dependencies for just that is definitely understandable. For context, it was a bit confusing for me as a noob because I tried running "cargo test" and it would succeed, only to later randomly fail. But maybe not worth an additional dependency and non-standard tests.

I changed it to run everything single-threadedly by default with .cargo/config.toml. The only downside is that it requires cargo 1.56 (2021), so I didn't remove the line from the Makefile. With this pull request I added a test that checks the RUST_TEST_THREADS env variable, because the tests are a bit invalid when running with multiple threads. The only downside I can see is if someone is trying to use pre 1.56 versions, (I didn't want to add version requirements to Cargo.toml) they can't use --test-threads=1, but I made the assert message tell them to use RUST_TEST_THREADS instead.