### PR TITLE
Add auto-territory attribute to i18n!

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,11 @@ pub fn locale() -> String {
     CURRENT_LOCALE.read().unwrap().to_string()
 }
 
+/// Get language territory from locale
+pub fn language_territory(locale: &str) -> Option<&str> {
+    locale.split_once(&['-', '_']).map(|(a, _)| a)
+}
+
 /// Get I18n text
 ///
 /// ```no_run

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -68,6 +68,18 @@ mod tests {
         rust_i18n::i18n!(fallback = "foo");
     }
 
+    mod test4 {
+        rust_i18n::i18n!("./tests/locales", fallback = "en", auto_territory = true);
+
+        #[test]
+        fn test_auto_territory() {
+            assert_eq!(
+                crate::tests::test2::_rust_i18n_translate("zh-SG", "hello"),
+                "Bar - 你好世界！"
+            );
+        }
+    }
+
     #[test]
     fn check_test_environment() {
         assert_eq!(
@@ -98,7 +110,7 @@ mod tests {
     fn test_available_locales() {
         assert_eq!(
             rust_i18n::available_locales!(),
-            &["en", "ja", "pt", "zh-CN"]
+            &["en", "ja", "pt", "zh", "zh-CN"]
         );
     }
 

--- a/tests/locales/zh.yml
+++ b/tests/locales/zh.yml
@@ -1,0 +1,4 @@
+hello: Bar - 你好世界！
+messages:
+  hello: 你好，%{name}！
+  other: 你收到了 %{count} 条新消息。


### PR DESCRIPTION
Add a new attribute `auto_territory` to the i18n!

```rust
i18n!("locales", fallback = "en", auto_territory = true);
```

The new attribute `auto_territory` for set the auto territory flag, if `true` `t` macro will auto fallback to the language territory of the locale when missing, like: `zh-SG` => `zh`, if `zh` still missing, then fallback to the `fallback` locale.
