### PR TITLE
Add lookup fallback to t!

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ rust-i18n = "2"
 
 Load macro and init translations in `lib.rs` or `main.rs`:
 
-```rust,no_run
+```rust,compile_fail,no_run
 // Load I18n macro, for allow you use `t!` macro in anywhere.
 #[macro_use]
 extern crate rust_i18n;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -98,7 +98,7 @@ mod tests {
     fn test_available_locales() {
         assert_eq!(
             rust_i18n::available_locales!(),
-            &["en", "ja", "pt", "zh-CN"]
+            &["en", "ja", "pt", "zh", "zh-CN"]
         );
     }
 
@@ -285,6 +285,18 @@ mod tests {
         assert_eq!(
             t!("nested_locale_test.hello.world", locale = "ja"),
             "こんにちは test3"
+        );
+    }
+
+    #[test]
+    fn test_lookup_fallback() {
+        assert_eq!(
+            t!("missing.lookup-fallback", locale = "zh-CN"),
+            "在 zh-XXX 中缺失的的翻译。"
+        );
+        assert_eq!(
+            t!("missing.default", locale = "zh-CN", fallback = "en"),
+            "This is missing key fallbacked to en."
         );
     }
 }

--- a/tests/locales/zh.yml
+++ b/tests/locales/zh.yml
@@ -1,0 +1,2 @@
+missing:
+  lookup-fallback: 在 zh-XXX 中缺失的的翻译。


### PR DESCRIPTION
Add lookup fallback to t!

Example of a Lookup Fallback Pattern

Range to match: zh-Hant-CN-x-private1-private2
1. zh-Hant-CN-x-private1-private2
2. zh-Hant-CN-x-private1
3. zh-Hant-CN
4. zh-Hant
5. zh
6. (default)

Closed: #67 