### PR TITLE
Add chained fallback support and performance improved

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ version = "2.3.1"
 once_cell = "1.10.0"
 rust-i18n-support = {path = "./crates/support", version = "2.3.0"}
 rust-i18n-macro = {path = "./crates/macro", version = "2.3.0"}
+smallvec = "1.12.0"
 
 [dev-dependencies]
 foo = {path = "examples/foo"}

--- a/README.md
+++ b/README.md
@@ -374,8 +374,12 @@ $ RUST_I18N_DEBUG=1 cargo build
 Benchmark `t!` method, result on Apple M1:
 
 ```bash
-t                       time:   [100.91 ns 101.06 ns 101.24 ns]
-t_with_args             time:   [495.56 ns 497.88 ns 500.64 ns]
+t                       time:   [58.274 ns 60.222 ns 62.390 ns]
+t_with_locale           time:   [55.395 ns 57.106 ns 59.081 ns]
+t_with_args             time:   [167.46 ns 170.94 ns 175.64 ns]
+t_with_args (str)       time:   [164.85 ns 165.91 ns 167.41 ns]
+t_with_args (many)      time:   [444.04 ns 452.17 ns 463.44 ns]
+t_with_threads          time:   [414.26 ns 422.97 ns 433.53 ns]
 ```
 
 The result `101 ns (0.0001 ms)` means if there have 10K translate texts, it will cost 1ms.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ You can use `rust_i18n::set_locale` to set the global locale at runtime, so that
 rust_i18n::set_locale("zh-CN");
 
 let locale = rust_i18n::locale();
-assert_eq!(locale, "zh-CN");
+assert_eq!(*locale, "zh-CN");
 ```
 
 ### Extend Backend

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ i18n!("locales");
 // Use `fallback` option to set fallback locale.
 //
 // i18n!("locales", fallback = "en");
+
+// Or more than one fallback with priority.
+//
+// i18n!("locales", fallback = ["en", "es]);
 ```
 
 Or you can import by use directly:

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -64,6 +64,21 @@ fn bench_t(c: &mut Criterion) {
     c.bench_function("t_with_args (str)", |b| {
         b.iter(|| t!("a.very.nested.message", "name" = "Jason", "msg" = "Bla bla"))
     });
+
+    c.bench_function("t_with_args (many)", |b| {
+        b.iter(|| {
+            t!(
+                "a.very.nested.response",
+                id = 123,
+                name = "Marion",
+                surname = "Christiansen",
+                email = "Marion_Christiansen83@hotmail.com",
+                city = "Litteltown",
+                zip = 8408,
+                website = "https://snoopy-napkin.name"
+            )
+        })
+    });
 }
 
 criterion_group!(benches, bench_t);

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -18,7 +18,7 @@ rust-i18n-support = { path = "../support", version = "2.3.0" }
 serde = "1"
 serde_json = "1"
 serde_yaml = "0.8"
-syn = "2.0.18"
+syn = { version = "2.0.18", features = ["full"] }
 
 [dev-dependencies]
 rust-i18n = { path = "../.." }

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -198,6 +198,7 @@ fn generate_code(
     // result
     quote! {
         use rust_i18n::BackendExt;
+        use std::borrow::Cow;
 
         /// I18n backend instance
         ///
@@ -227,15 +228,15 @@ fn generate_code(
         /// Get I18n text by locale and key
         #[inline]
         #[allow(missing_docs)]
-        pub fn _rust_i18n_translate(locale: &str, key: &str) -> String {
+        pub fn _rust_i18n_translate<'r>(locale: &str, key: &'r str) -> Cow<'r, str> {
             if let Some(value) = _RUST_I18N_BACKEND.translate(locale, key) {
-                return value.to_string();
+                return value.into();
             }
 
             let mut current_locale = locale;
             while let Some(fallback_locale) = _rust_i18n_lookup_fallback(current_locale) {
                 if let Some(value) = _RUST_I18N_BACKEND.translate(fallback_locale, key) {
-                    return value.to_string();
+                    return value.into();
                 }
                 current_locale = fallback_locale;
             }
@@ -243,15 +244,15 @@ fn generate_code(
             if let Some(fallback) = _RUST_I18N_FALLBACK_LOCALE {
                 for locale in fallback {
                     if let Some(value) = _RUST_I18N_BACKEND.translate(locale, key) {
-                        return value.to_string();
+                        return value.into();
                     }
                 }
             }
 
             if locale.is_empty() {
-                return key.to_string();
+                return key.into();
             }
-            return format!("{}.{}", locale, key);
+            return format!("{}.{}", locale, key).into();
         }
 
         #[allow(missing_docs)]

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -20,27 +20,27 @@ impl Args {
     fn consume_fallback(&mut self, input: syn::parse::ParseStream) -> syn::parse::Result<()> {
         if let Ok(val) = input.parse::<LitStr>() {
             self.fallback = Some(vec![val.value()]);
-        } else {
-            let val = input.parse::<syn::ExprArray>()?;
-            let fallback = val
-                .elems
-                .into_iter()
-                .map(|expr| {
-                    if let syn::Expr::Lit(syn::ExprLit {
-                        lit: syn::Lit::Str(lit_str),
-                        ..
-                    }) = expr
-                    {
-                        Ok(lit_str.value())
-                    } else {
-                        Err(input.error(
-                            "`fallback` must be a string literal or an array of string literals",
-                        ))
-                    }
-                })
-                .collect::<syn::parse::Result<Vec<String>>>()?;
-            self.fallback = Some(fallback);
+            return Ok(());
         }
+        let val = input.parse::<syn::ExprArray>()?;
+        let fallback = val
+            .elems
+            .into_iter()
+            .map(|expr| {
+                if let syn::Expr::Lit(syn::ExprLit {
+                    lit: syn::Lit::Str(lit_str),
+                    ..
+                }) = expr
+                {
+                    Ok(lit_str.value())
+                } else {
+                    Err(input.error(
+                        "`fallback` must be a string literal or an array of string literals",
+                    ))
+                }
+            })
+            .collect::<syn::parse::Result<Vec<String>>>()?;
+        self.fallback = Some(fallback);
         Ok(())
     }
 

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -262,3 +262,15 @@ fn generate_code(
         }
     }
 }
+
+#[proc_macro]
+pub fn key(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let output = syn::parse::<syn::LitStr>(input.clone())
+        .map(|str| str.value())
+        .or(syn::parse::<syn::Ident>(input.clone()).map(|ident| format!("{}", ident)));
+
+    match output {
+        Ok(value) => quote! { #value }.into(),
+        Err(err) => err.to_compile_error().into(),
+    }
+}

--- a/crates/macro/src/lib.rs
+++ b/crates/macro/src/lib.rs
@@ -127,7 +127,7 @@ impl syn::parse::Parse for Args {
 /// # }
 /// # fn v3() {
 /// i18n!("locales", fallback = "en");
-/// #}
+/// # }
 /// # fn v4() {
 /// i18n!("locales", fallback = ["en", "es"]);
 /// # }

--- a/crates/support/src/atomic_str.rs
+++ b/crates/support/src/atomic_str.rs
@@ -1,0 +1,80 @@
+use std::fmt;
+use std::sync::atomic::{AtomicPtr, Ordering};
+use std::sync::Arc;
+
+/// A thread-safe atomically reference-counting string.
+pub struct AtomicStr(AtomicPtr<String>);
+
+impl AtomicStr {
+    /// Create a new `AtomicStr` with the given value.
+    pub fn new(value: impl Into<String>) -> Self {
+        let arced = Arc::new(value.into());
+        Self(AtomicPtr::new(Arc::into_raw(arced) as _))
+    }
+
+    /// Get the string slice.
+    pub fn as_str(&self) -> &str {
+        unsafe {
+            let arced_ptr = self.0.load(Ordering::SeqCst);
+            assert!(!arced_ptr.is_null());
+            &*arced_ptr
+        }
+    }
+
+    /// Get the cloned inner `Arc<String>`.
+    pub fn clone_string(&self) -> Arc<String> {
+        unsafe {
+            let arced_ptr = self.0.load(Ordering::SeqCst);
+            assert!(!arced_ptr.is_null());
+            Arc::increment_strong_count(arced_ptr);
+            Arc::from_raw(arced_ptr)
+        }
+    }
+
+    /// Replaces the value at self with src, returning the old value, without dropping either.
+    pub fn replace(&self, src: impl Into<String>) -> Arc<String> {
+        unsafe {
+            let arced_new = Arc::new(src.into());
+            let arced_old_ptr = self.0.swap(Arc::into_raw(arced_new) as _, Ordering::SeqCst);
+            assert!(!arced_old_ptr.is_null());
+            Arc::from_raw(arced_old_ptr)
+        }
+    }
+}
+
+impl Drop for AtomicStr {
+    fn drop(&mut self) {
+        unsafe {
+            let arced_ptr = self.0.swap(std::ptr::null_mut(), Ordering::SeqCst);
+            assert!(!arced_ptr.is_null());
+            let _ = Arc::from_raw(arced_ptr);
+        }
+    }
+}
+
+impl AsRef<str> for AtomicStr {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<T> From<T> for AtomicStr
+where
+    T: Into<String>,
+{
+    fn from(value: T) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<&AtomicStr> for Arc<String> {
+    fn from(value: &AtomicStr) -> Self {
+        value.clone_string()
+    }
+}
+
+impl fmt::Display for AtomicStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}

--- a/crates/support/src/lib.rs
+++ b/crates/support/src/lib.rs
@@ -3,7 +3,9 @@ use std::fs::File;
 use std::io::prelude::*;
 use std::{collections::HashMap, path::Path};
 
+mod atomic_str;
 mod backend;
+pub use atomic_str::AtomicStr;
 pub use backend::{Backend, BackendExt, SimpleBackend};
 
 type Locale = String;

--- a/examples/app-load-path/src/main.rs
+++ b/examples/app-load-path/src/main.rs
@@ -5,7 +5,7 @@ extern crate rust_i18n;
 i18n!("../locales");
 
 fn hello() -> String {
-    t!("hello")
+    t!("hello").into()
 }
 
 fn main() {

--- a/examples/app-workspace/app1/src/main.rs
+++ b/examples/app-workspace/app1/src/main.rs
@@ -5,7 +5,7 @@ extern crate rust_i18n;
 i18n!("../locales");
 
 fn get_text() -> String {
-    t!("hello")
+    t!("hello").into()
 }
 
 fn main() {

--- a/examples/app-workspace/crates/example-base/src/lib.rs
+++ b/examples/app-workspace/crates/example-base/src/lib.rs
@@ -5,5 +5,5 @@ extern crate rust_i18n;
 i18n!("locales");
 
 pub fn hello(name: &str) -> String {
-    t!("hello", name = name)
+    t!("hello", name = name).into()
 }

--- a/examples/foo/src/info.rs
+++ b/examples/foo/src/info.rs
@@ -2,7 +2,7 @@ use rust_i18n::t;
 
 #[allow(unused)]
 pub fn get_info() -> String {
-    t!("hello")
+    t!("hello").into()
 }
 
 #[cfg(test)]

--- a/examples/foo/src/lib.rs
+++ b/examples/foo/src/lib.rs
@@ -5,5 +5,5 @@ mod info;
 rust_i18n::i18n!("locales", fallback = "en");
 
 pub fn t(key: &str) -> String {
-    t!(key)
+    t!(key).to_string()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,72 @@ pub fn locale() -> Arc<String> {
     CURRENT_LOCALE.clone_string()
 }
 
+/// Replace patterns and return a new string.
+///
+/// # Arguments
+///
+/// * `input` - The input string, containing patterns like `%{name}`.
+/// * `patterns` - The patterns to replace.
+/// * `values` - The values to replace.
+///
+/// # Example
+///
+/// ```
+/// # use rust_i18n::replace_patterns;
+/// let input = "Hello, %{name}!";
+/// let patterns = &["name"];
+/// let values = &["world".to_string()];
+/// let output = replace_patterns(input, patterns, values);
+/// assert_eq!(output, "Hello, world!");
+/// ```
+pub fn replace_patterns(input: &str, patterns: &[&str], values: &[String]) -> String {
+    let input_bytes = input.as_bytes();
+    let mut pattern_pos = smallvec::SmallVec::<[usize; 64]>::new();
+    let mut stage = 0;
+    for (i, &b) in input_bytes.iter().enumerate() {
+        match (stage, b) {
+            (1, b'{') => {
+                stage = 2;
+                pattern_pos.push(i);
+            }
+            (2, b'}') => {
+                stage = 0;
+                pattern_pos.push(i);
+            }
+            (_, b'%') => {
+                stage = 1;
+            }
+            _ => {}
+        }
+    }
+    let mut output: Vec<u8> = Vec::with_capacity(input_bytes.len() + 128);
+    let mut prev_end = 0;
+    let pattern_values = patterns.iter().zip(values.iter());
+    for pos in pattern_pos.chunks_exact(2) {
+        let start = pos[0];
+        let end = pos[1];
+        let key = &input_bytes[start + 1..end];
+        if prev_end < start {
+            let prev_chunk = &input_bytes[prev_end..start - 1];
+            output.extend_from_slice(prev_chunk);
+        }
+        if let Some((_, v)) = pattern_values
+            .clone()
+            .find(|(&pattern, _)| pattern.as_bytes() == key)
+        {
+            output.extend_from_slice(v.as_bytes());
+        } else {
+            output.extend_from_slice(&input_bytes[start - 1..end + 1]);
+        }
+        prev_end = end + 1;
+    }
+    if prev_end < input_bytes.len() {
+        let remaining = &input_bytes[prev_end..];
+        output.extend_from_slice(remaining);
+    }
+    unsafe { String::from_utf8_unchecked(output) }
+}
+
 /// Get I18n text
 ///
 /// ```no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,8 @@ macro_rules! t {
                 $(format!("{}", $var_val)),+
             ];
 
-            rust_i18n::replace_patterns(message.as_ref(), patterns, values)
+            let output = rust_i18n::replace_patterns(message.as_ref(), patterns, values);
+            std::borrow::Cow::from(output)
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,23 @@
 #![doc = include_str!("../README.md")]
 
 use once_cell::sync::Lazy;
-use std::sync::RwLock;
+use std::sync::Arc;
 
 #[doc(hidden)]
 pub use once_cell;
 pub use rust_i18n_macro::i18n;
-pub use rust_i18n_support::{Backend, BackendExt, SimpleBackend};
+pub use rust_i18n_support::{AtomicStr, Backend, BackendExt, SimpleBackend};
 
-static CURRENT_LOCALE: Lazy<RwLock<String>> = Lazy::new(|| RwLock::new(String::from("en")));
+static CURRENT_LOCALE: Lazy<AtomicStr> = Lazy::new(|| AtomicStr::from("en"));
 
 /// Set current locale
 pub fn set_locale(locale: &str) {
-    let mut current_locale = CURRENT_LOCALE.write().unwrap();
-    *current_locale = locale.to_string();
+    CURRENT_LOCALE.replace(locale);
 }
 
 /// Get current locale
-pub fn locale() -> String {
-    CURRENT_LOCALE.read().unwrap().to_string()
+pub fn locale() -> Arc<String> {
+    CURRENT_LOCALE.clone_string()
 }
 
 /// Get I18n text

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -216,10 +216,8 @@ mod tests {
 
         let key = "messages.hello";
 
-        assert_eq!(
-            t!(&format!("messages.{}", "hello"), name = name),
-            "Hello, Jason Lee!"
-        );
+        let dyn_key = format!("messages.{}", "hello");
+        assert_eq!(t!(&dyn_key, name = name), "Hello, Jason Lee!");
         assert_eq!(t!(key, name = name), "Hello, Jason Lee!");
 
         assert_eq!(t!("messages.hello", name = name), "Hello, Jason Lee!");

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -68,6 +68,22 @@ mod tests {
         rust_i18n::i18n!(fallback = "foo");
     }
 
+    mod test4 {
+        rust_i18n::i18n!("./tests/locales", fallback = ["zh", "en"]);
+
+        #[test]
+        fn test_fallback() {
+            assert_eq!(
+                crate::tests::test4::_rust_i18n_translate("zh-CN", "messages.zero"),
+                "你没有消息。"
+            );
+            assert_eq!(
+                crate::tests::test4::_rust_i18n_translate("zh-CN", "messages.one"),
+                "You have one message."
+            );
+        }
+    }
+
     #[test]
     fn check_test_environment() {
         assert_eq!(

--- a/tests/locales/en.yml
+++ b/tests/locales/en.yml
@@ -12,3 +12,6 @@ messages:
   hello: Hello, %{name}!
 missing:
   default: This is missing key fallbacked to en.
+lorem-ipsum: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sed nisi leo. Donec commodo in ex at aliquam. Nunc in aliquam arcu. Fusce mollis metus orci, ut sagittis erat lobortis sed. Morbi quis arcu ultrices turpis finibus tincidunt non in purus. Donec gravida condimentum sapien. Duis iaculis fermentum congue. Quisque blandit libero a lacus auctor vestibulum. Nunc efficitur sollicitudin nisi, sit amet tristique lectus mollis non. Praesent sit amet erat volutpat, pharetra orci eget, rutrum felis. Sed elit augue, imperdiet eu facilisis vel, finibus vel urna. Duis quis neque metus.
+
+  Mauris suscipit bibendum mattis. Vestibulum eu augue diam. Morbi dapibus tempus viverra. Sed aliquam turpis eget justo ornare maximus vitae et tortor. Donec semper neque sit amet sapien congue scelerisque. Maecenas bibendum imperdiet dolor interdum facilisis. Integer non diam tempus, pharetra ex at, euismod diam. Ut enim turpis, sagittis in iaculis ut, finibus et sem. Suspendisse a felis euismod neque euismod placerat. Praesent ipsum libero, porta vel egestas quis, aliquet vitae lorem. Nullam vel pharetra erat, sit amet sodales leo.

--- a/tests/locales/en.yml
+++ b/tests/locales/en.yml
@@ -5,6 +5,9 @@ a:
   very:
     nested:
       message: "Hello, %{name}. Your message is: %{msg}"
+      response: Hello %{name} %{surname}, your account id is %{id}, email address is %{email}. 
+        You live in %{city} %{zip}. 
+        Your website is %{website}.
 messages:
   zero: You have no messages.
   one: You have one message.

--- a/tests/locales/zh.yml
+++ b/tests/locales/zh.yml
@@ -1,2 +1,4 @@
+messages:
+  zero: 你没有消息。
 missing:
   lookup-fallback: 在 zh-XXX 中缺失的的翻译。


### PR DESCRIPTION
# New:
- Add more than one fallback with priority support, eg: `i18n!("locales", fallback = ["en", "es]);` 
  - #40
# Improved:
- Remove `RwLock` from `locale()` and `set_locale()`.
- String patterns replacement, time reduce 10% ~ 80%.
- Reduce memory copy on `t!()`.
# Breaking Changes:
- `rust_i18n::locale() -> String` => `rust_i18n::locale() -> Arc<String>` .
- `t!() -> String` => `t!() -> Cow<str>`.
