### PR TITLE
🦊 Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,21 +22,52 @@ readme = "README.md"
 repository = "https://github.com/longbridgeapp/rust-i18n"
 version = "3.0.2-alpha.0"
 
-[dependencies]
+[workspace.dependencies]
+anyhow = "1"
+arc-swap = "1.6.0"
+base62 = "2.0.2"
+clap = { version = "4.1.14", features = ["derive"] }
+criterion = "0.5"
+foo = { path = "examples/foo" }
+glob = "0.3"
+globwalk = "0.8.1"
+ignore = "0.4"
+indoc = "1"
+itertools = "0.11.0"
+lazy_static = "1"
+normpath = "1.1.1"
 once_cell = "1.10.0"
-rust-i18n-support = { path = "./crates/support", version = "3.0.1" }
+proc-macro2 = { version = "1", features = ["span-locations"] }
+quote = "1.0.2"
+regex = "1"
+rust-i18n = { path = "." }
+rust-i18n-extract = { path = "./crates/extract", version = "3.0.0" }
 rust-i18n-macro = { path = "./crates/macro", version = "3.0.0" }
+rust-i18n-support = { path = "./crates/support", version = "3.0.1" }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9.30"
+siphasher = "1.0"
 smallvec = "1.12.0"
+syn = { version = "2.0.18", features = ["full", "extra-traits"] }
+toml = "0.8.8"
+triomphe = { version = "0.1.11", features = ["arc-swap"] }
+
+[dependencies]
+once_cell.workspace = true
+rust-i18n-support.workspace = true
+rust-i18n-macro.workspace = true
+smallvec.workspace = true
 
 [dev-dependencies]
-foo = { path = "examples/foo" }
-criterion = "0.5"
-lazy_static = "1"
-serde_yaml = "0.8"
+foo.workspace = true
+criterion.workspace = true
+lazy_static.workspace = true
+serde_yaml.workspace = true
 
 [build-dependencies]
-globwalk = "0.8.1"
-regex = "1"
+globwalk.workspace = true
+regex.workspace = true
 
 [features]
 log-miss-tr = ["rust-i18n-macro/log-miss-tr"]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -8,10 +8,11 @@ repository = "https://github.com/longbridgeapp/rust-i18n"
 version = "3.0.0"
 
 [dependencies]
-anyhow = "1"
-clap = { version = "4.1.14", features = ["derive"] }
-rust-i18n-support = { path = "../support", version = "3.0.0" }
-rust-i18n-extract = { path = "../extract", version = "3.0.0" }
+anyhow.workspace = true
+clap.workspace = true
+
+rust-i18n-support.workspace = true
+rust-i18n-extract.workspace = true
 
 [[bin]]
 name = "cargo-i18n"

--- a/crates/extract/Cargo.toml
+++ b/crates/extract/Cargo.toml
@@ -7,20 +7,18 @@ readme = "../../README.md"
 repository = "https://github.com/longbridgeapp/rust-i18n"
 version = "3.0.0"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-anyhow = "1"
-ignore = "0.4"
-proc-macro2 = { version = "1", features = ["span-locations"] }
-quote = "1"
-regex = "1"
-rust-i18n-support = { path = "../support", version = "3.0.0" }
-serde = "1"
-serde_json = "1"
-serde_yaml = "0.8"
-syn = { version = "2.0.18", features = ["full"] }
-toml = "0.7.4"
+anyhow.workspace = true
+ignore.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+regex.workspace = true
+rust-i18n-support.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+syn.workspace = true
+toml.workspace = true
 
 [dev-dependencies]
-indoc = "1"
+indoc.workspace = true

--- a/crates/macro/Cargo.toml
+++ b/crates/macro/Cargo.toml
@@ -10,18 +10,18 @@ version = "3.0.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-glob = "0.3"
-once_cell = "1.10.0"
-proc-macro2 = "1.0"
-quote = "1.0.2"
-rust-i18n-support = { path = "../support", version = "3.0.0" }
-serde = "1"
-serde_json = "1"
-serde_yaml = "0.8"
-syn = { version = "2.0.18", features = ["full", "extra-traits"] }
+glob.workspace = true
+once_cell.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+rust-i18n-support.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+syn.workspace = true
 
 [dev-dependencies]
-rust-i18n = { path = "../.." }
+rust-i18n.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/support/Cargo.toml
+++ b/crates/support/Cargo.toml
@@ -8,18 +8,18 @@ repository = "https://github.com/longbridgeapp/rust-i18n"
 version = "3.0.1"
 
 [dependencies]
-arc-swap = "1.6.0"
-base62 = "2.0.2"
-globwalk = "0.8.1"
-itertools = "0.11.0"
-once_cell = "1.10.0"
-proc-macro2 = "1.0"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde_yaml = "0.8"
-siphasher = "1.0"
-toml = "0.7.4"
-normpath = "1.1.1"
-lazy_static = "1"
-regex = "1"
-triomphe = { version = "0.1.11", features = ["arc-swap"] }
+arc-swap.workspace = true
+base62.workspace = true
+globwalk.workspace = true
+itertools.workspace = true
+once_cell.workspace = true
+proc-macro2.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_yaml.workspace = true
+siphasher.workspace = true
+toml.workspace = true
+normpath.workspace = true
+lazy_static.workspace = true
+regex.workspace = true
+triomphe.workspace = true


### PR DESCRIPTION
We have a pretty strict CI for duplicate dependencies in our project, and it cought some out-dated dependencies when integrating `rust-i18n` into our project.

This PR switches this project over to use [workspace dependencies](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) for ease of use (now there's only one place where all the versions are defined, so only one place to update!)

I've also taken the liberty in this PR to update some of the dependencies to at least be on the same level as our project (for example: serde_yaml 0.8 had a security warning issues against it because it depended on `yaml-rust`  which was left unmaintained).