### PR TITLE
Fix spelling error in README (verison vs version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can use `_version` key to specify the version (This version is the locale fi
 rust-i18n supports two style of config file, and those versions will always be keeping.
 
 - `_version: 1` - Split each locale into difference files, it is useful when your project wants to split to translate work.
-- `_verison: 2` - Put all localized text into same file, it is easy to translate quickly by AI (e.g.: GitHub Copilot). When you write original text, just press Enter key, then AI will suggest you the translation text for other languages.
+- `_version: 2` - Put all localized text into same file, it is easy to translate quickly by AI (e.g.: GitHub Copilot). When you write original text, just press Enter key, then AI will suggest you the translation text for other languages.
 
 You can choose as you like.
 


### PR DESCRIPTION
This pull request just fixes a little typo in the `README.md` wich was catching my attention while reading it.