### PR TITLE
Add optional i18n.toml configuration file for the CLI tool

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,6 +5,8 @@ use rust_i18n_extract::{extractor, generator, iter};
 use rust_i18n_support::{I18nConfig, MinifyKey};
 use std::{collections::HashMap, path::Path};
 
+const I18N_CONFIG_FILE: &str = "i18n.toml";
+
 #[derive(Parser)]
 #[command(name = "cargo")]
 #[command(bin_name = "cargo")]
@@ -96,6 +98,20 @@ fn add_translations(
     }
 }
 
+fn read_config(source_path: &str) -> std::io::Result<I18nConfig> {
+    let root_dir = std::path::Path::new(&source_path);
+    let config_file = root_dir.join(I18N_CONFIG_FILE);
+
+    let config_file_exists = std::fs::exists(&config_file)
+        .unwrap_or_else(|err| panic!("Error opening '{I18N_CONFIG_FILE}': {err}"));
+
+    if config_file_exists {
+        I18nConfig::load_from_file(&config_file)
+    } else {
+        I18nConfig::load(&root_dir.join("Cargo.toml"))
+    }
+}
+
 fn main() -> Result<(), Error> {
     let CargoCli::I18n(args) = CargoCli::parse();
 
@@ -103,7 +119,7 @@ fn main() -> Result<(), Error> {
 
     let source_path = args.source.expect("Missing source path");
 
-    let cfg = I18nConfig::load(std::path::Path::new(&source_path))?;
+    let cfg = read_config(&source_path)?;
 
     iter::iter_crate(&source_path, |path, source| {
         extractor::extract(&mut results, path, source, cfg.clone())

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -110,7 +110,7 @@ fn read_config(source_path: &str) -> std::io::Result<I18nConfig> {
     if config_file_exists {
         I18nConfig::load_from_file(&config_file)
     } else {
-        I18nConfig::load(&root_dir.join("Cargo.toml"))
+        I18nConfig::load(&root_dir)
     }
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -98,6 +98,8 @@ fn add_translations(
     }
 }
 
+/// Reads the configuration either from the `i18n.toml` file, if present,
+/// or from the `Cargo.toml` file otherwise.
 fn read_config(source_path: &str) -> std::io::Result<I18nConfig> {
     let root_dir = std::path::Path::new(&source_path);
     let config_file = root_dir.join(I18N_CONFIG_FILE);

--- a/crates/support/src/config.rs
+++ b/crates/support/src/config.rs
@@ -54,7 +54,17 @@ impl I18nConfig {
     pub fn load(cargo_root: &Path) -> io::Result<Self> {
         let cargo_file = cargo_root.join("Cargo.toml");
         let mut file = fs::File::open(&cargo_file)
-            .unwrap_or_else(|e| panic!("Fail to open {}, {}", cargo_file.display(), e));
+            .unwrap_or_else(|e| panic!("Failed to open {}, {}", cargo_file.display(), e));
+
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)?;
+
+        Self::parse(&contents)
+    }
+
+    pub fn load_from_file(file: &Path) -> io::Result<Self> {
+        let mut file = fs::File::open(file)
+            .unwrap_or_else(|e| panic!("Failed to open {}, {}", file.display(), e));
 
         let mut contents = String::new();
         file.read_to_string(&mut contents)?;
@@ -204,6 +214,16 @@ fn test_load() {
     let cargo_root = workdir.join("../../examples/foo");
 
     let cfg = I18nConfig::load(&cargo_root).unwrap();
+    assert_eq!(cfg.default_locale, "en");
+    assert_eq!(cfg.available_locales, vec!["en", "zh-CN"]);
+}
+
+#[test]
+fn test_load_from_file() {
+    let workdir = Path::new(env!["CARGO_MANIFEST_DIR"]);
+    let file = workdir.join("../../examples/foo/i18n.toml");
+
+    let cfg = I18nConfig::load_from_file(&file).unwrap();
     assert_eq!(cfg.default_locale, "en");
     assert_eq!(cfg.available_locales, vec!["en", "zh-CN"]);
 }

--- a/examples/foo/i18n.toml
+++ b/examples/foo/i18n.toml
@@ -1,0 +1,3 @@
+[i18n]
+available-locales = ["en", "zh-CN"]
+default-locale = "en"


### PR DESCRIPTION
Currently, the CLI tool `i18n` only supports reading the configuration from the `Cargo.toml` file in the root source directory.

However, in larger projects, the `Cargo.toml` file can quickly become very full and confusing with options from various tools.

With this PR, it is now possible to optionally create an `i18n.toml` file in the source root, from which the configuration can be loaded instead.

For example:

```toml
# i18n.toml
[i18n]
available-locales = ["en", "de"]
default-locale = "en"
load-path = "locales"
```

The priorities are then as follows:

- If `i18n.toml` exists in the source root, load the configuration from there.
- If `i18n.toml` doesn't exist, load the configuration from `Cargo.toml`.