### PR TITLE
🍞 Check for old / stale translations

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -120,6 +120,11 @@ fn main() -> Result<(), Error> {
 
     let output_path = Path::new(&source_path).join(&cfg.load_path);
 
+    let result = generator::stale(&output_path, &cfg.available_locales, messages.clone());
+    if result.is_err() {
+        has_error = true;
+    }
+
     let result = generator::generate(output_path, &cfg.available_locales, messages.clone());
     if result.is_err() {
         has_error = true;


### PR DESCRIPTION
I noticed in our application we had some phrases that still existed in our `app.yml` file, but weren't used in the application anymore, causing unnecessary work for our translators. This PR adds a bit of code to detect these and write out a `STALE.yml` file (next to `TODO.yml`) so they can be manually removed.